### PR TITLE
fix: Update lxml_html_clean version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ asyncio==3.4.3
 httpx>=0.23.0,<1.0.0
 bleach==6.2.0
 lxml>=4.9.3
-lxml_html_clean>=1.0.0
+lxml_html_clean==0.4.1


### PR DESCRIPTION
- Set lxml_html_clean to version 0.4.1
- Fix dependency resolution error
- Fix Heroku build failure